### PR TITLE
Load PNG/JPG file fix for Custom Ball

### DIFF
--- a/svg_utils.py
+++ b/svg_utils.py
@@ -10,38 +10,46 @@
 # along with this library; if not, write to the Free Software
 # Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
 from gi.repository import GdkPixbuf
-
+import base64
 from math import sin, cos, pi
 
 
 def generate_ball_svg(path):
     ''' Returns an SVG string of a ball + label with image from path '''
-    return \
-        '<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n' + \
-        '<svg\n' + \
-        'xmlns:dc="http://purl.org/dc/elements/1.1/"\n' + \
-        'xmlns:cc="http://creativecommons.org/ns#"\n' + \
-        'xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"\n' + \
-        'xmlns:svg="http://www.w3.org/2000/svg"\n' + \
-        'xmlns="http://www.w3.org/2000/svg"\n' + \
-        'xmlns:xlink="http://www.w3.org/1999/xlink"\n' + \
-        'version="1.1"\n' + \
-        'width="85"\n' + \
-        'height="120">\n' + \
-        '<image\n' + \
-        'xlink:href="file://%s"\n' % path + \
-        'x="0"\n' + \
-        'y="35"\n' + \
-        'width="85"\n' + \
-        'height="85" />\n' + \
-        '<rect\n' + \
-        'width="85"\n' + \
-        'height="35"\n' + \
-        'ry="7.75"\n' + \
-        'x="0"\n' + \
-        'y="0"\n' + \
-        'style="fill:#ffffff;fill-opacity:1;stroke:none" />\n' + \
-        '</svg>'
+    with open(path, 'rb') as w:
+        x = w.read()
+    base64_embed = base64.b64encode(x).decode()
+    type_embed = path.split('.')[-1]
+    print(path, 'kkk')
+    a =  """<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+xmlns:dc="http://purl.org/dc/elements/1.1/"
+xmlns:cc="http://creativecommons.org/ns#"
+xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+xmlns:svg="http://www.w3.org/2000/svg"
+xmlns="http://www.w3.org/2000/svg"
+xmlns:xlink="http://www.w3.org/1999/xlink"
+version="1.1"
+width="85"
+height="120">
+<image
+xlink:href="data:image/png;base64,{}
+"
+x="0"
+y="35"
+width="85"
+height="85" />
+<rect
+width="85"
+height="35"
+ry="7.75"
+x="0"
+y="0"
+style="fill:#ffffff;fill-opacity:1;stroke:none" />
+</svg>
+""".format(base64_embed)
+    print(a)
+    return a
 
 
 def generate_xo_svg(scale=1.0, colors=["#C0C0C0", "#282828"]):

--- a/svg_utils.py
+++ b/svg_utils.py
@@ -20,7 +20,6 @@ def generate_ball_svg(path):
         x = w.read()
     base64_embed = base64.b64encode(x).decode()
     type_embed = path.split('.')[-1]
-    print(path, 'kkk')
     a =  """<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
 xmlns:dc="http://purl.org/dc/elements/1.1/"
@@ -33,7 +32,7 @@ version="1.1"
 width="85"
 height="120">
 <image
-xlink:href="data:image/png;base64,{}
+xlink:href="data:image/{};base64,{}
 "
 x="0"
 y="35"
@@ -47,8 +46,7 @@ x="0"
 y="0"
 style="fill:#ffffff;fill-opacity:1;stroke:none" />
 </svg>
-""".format(base64_embed)
-    print(a)
+""".format(type_embed, base64_embed)
     return a
 
 


### PR DESCRIPTION
The Activity gave error message when I tried to load the image as the ball, but no messages when I loaded a custom background. 

__Assumed Reason:__
Gdk might not process `xlink:href` on files or `files:///` on svg. The SVG Pixbuf option might be underdeveloped.

__Test Work Flow__
The current generated SVG String (as of master) was tested on inkscape, and generated good results, but on loading it to the GdkPixbufLoader, it gives the error.

__Artifacts__
generated xml file on master branch 
```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<svg
xmlns:dc="http://purl.org/dc/elements/1.1/"
xmlns:cc="http://creativecommons.org/ns#"
xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
xmlns:svg="http://www.w3.org/2000/svg"
xmlns="http://www.w3.org/2000/svg"
xmlns:xlink="http://www.w3.org/1999/xlink"
version="1.1"
width="85"
height="120">
<image
xlink:href="file:///home/ss/.var/app/org.sugarlabs.FractionBounce/data/custom.png"
x="0"
y="35"
width="85"
height="85" />
<rect
width="85"
height="35"
ry="7.75"
x="0"
y="0"
style="fill:#ffffff;fill-opacity:1;stroke:none" />
</svg>
```

__Errors__
```
Traceback (most recent call last):
  File "/app/share/sugar/activities/FractionBounce.activity/FractionBounceActivity.py", line 426, in _load_ball_cb
    chooser(self, 'Image', self._new_ball_from_journal)
  File "/app/share/sugar/activities/FractionBounce.activity/utils.py", line 28, in chooser
    action(filepath)
  File "/app/share/sugar/activities/FractionBounce.activity/FractionBounceActivity.py", line 447, in _new_ball_from_journal
    os.path.join(os.environ['SUGAR_ACTIVITY_ROOT'], 'custom.png'))
  File "/app/share/sugar/activities/FractionBounce.activity/ball.py", line 144, in new_ball_from_image
    svg_str_to_pixbuf(generate_ball_svg(save_path)))
  File "/app/share/sugar/activities/FractionBounce.activity/svg_utils.py", line 58, in svg_str_to_pixbuf
    pl.close()
gi.repository.GLib.Error: rsvg-error-quark: Error displaying image (2)
```

__Applied Fix__
* Hardcode the generated png or jpeg file intoa base64 string, so the SVG file so generated will not have links, or symlinks to the existing / non-existent files

__Artifacts (for reference)__
The Following SVG snippet was generated by the patch, to avoid link issues or the errors
```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<svg
xmlns:dc="http://purl.org/dc/elements/1.1/"
xmlns:cc="http://creativecommons.org/ns#"
xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
xmlns:svg="http://www.w3.org/2000/svg"
xmlns="http://www.w3.org/2000/svg"
xmlns:xlink="http://www.w3.org/1999/xlink"
version="1.1"
width="85"
height="120">
<image
xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFUAAABVCAYAAAA49ahaAAAABHNCSVQICAgIfAhkiAAAEFBJREFUeJzlnUmTHMd1x38vq6q7Z8FKLFxBDChAJEaEJRI0SYVsUXLYOlgXhcyT7/oQ9oWfw3efoLAkXx0h2yHZpkKCSAkkQFDEIhILQRAYbDO9Vj4fXmZXdU93z9Y9QIMvIlGNmZ6sqn/9822Z+Up4SPKTVwFIlleotlocVOVJhSeBp4EDwH5gN8JelL3ALmAWmAFcX3f3gbvADeCq2vEKcBH4KLH/N05dpLMNt4ZM+gRvL+CARIVMoQZUgCpQFaEKzKI8obAPeAIDdE9oOzAwd4bPtdD6r3sZeADcBr5QuEUJWIEvMNDvAytOqAP5qQv4SdxzOolO+6QCzGOgPQMcxNh4UJV9GGCzoVUx0KqhZaFVwjEJrV9SYA57AE8BTaCOgXgHA/Ui8Ek4XsIeQn3cNwtjZOrbi9afb1BFqWHDdBYNrBOeBg5jwD4fjgcwIIaBtVXJgTYG7MfAOeBsOF71yg2g/rNLrIzzpONkqgv97cfYchhYwFi5N7Q4jONxFgNzUmpIwjXNh2vZARwBTij8EfgAY+2lcZ90U/KjFxFAXIsKUEOYQZjHcwQ4CrwMnAAOAbsxADd0QdL/A+05rPq8DvGAV1gCfoPyrsJpr5wWWM461AE9dWVjnfbLVpiaYrpuATiKcgjlCMbMJzDG7sNYko3qSAAROzoJLfzMlUDVgKDXAp3cG7DrBFewrueBRWCHwDOJcAj4HXAGUxlbMmAbZuqPF0z/acKcCjtdzivAG+Eiv4kN8woDdGT/ySITXaklQCLWXD+oGLBe7c473loEWQcweQ1ZAS6ifAj8As9/ACsuKXTsqYvr7yzKZpj6FPAsOcdEWMR05yGMmTtDn10oIgsTgTQC1weac3aMNIqsjcd+8WrAee1tHYW2t9bxkK+NboZ5IwLUcRzEGPs7oBPahmUkqG8/G24iQUjIEFI8h4FXBN5E+R7CLsz96QEyHp1A4iArtVTC0RXgJv3u/AYkDwC2PNQ70MzNp8IXD2CIZMB+hD2Yzj+KEf4icN/B8j9+zVTBv36y/utZD1Md5jueAL6OcALlBOYSzcc+JLQIVloCrducdVYe7hH4rYgEtVFx4DKoJsbUljeAW7mx2A9H12HBRgZ8V80dfFfg95iK2BBj1wNqgp1kEfgBcBwb9r03hgGXOaglUEuhkvSycVLiwhNNMGWuQcc2c3jQAhR8PtL6OMxD2R1u5VngAcJ5jPQbAnWgw/32IiweIPFmjE4i/B3CdzA3aT8w58QAqyYwm8BsBvOZHWtJAWjZkm+3dHW5C6MkXMMIxkapouRe2dVRJM+5tbiDfHEnevbe2ucdxtToNM8BryP8A2aMno5fcIGVMynMBBCryWQZuV4pu2dx5FRyWOmAts2QjZCdoX0bOIQiqpwXi8zW5b31MPWtt+DwYaRylznanBDPm6Hz4wI7HdQqCcymoQVWVhMzPok8HEauV8p+MKzpHXggQ1jB4TUh0YS75+6srQoGMVVQdqC8DvwtcAx4VgTnMFbOZ8aAajLc7XmURDAjFnV+JpayavuRtNuNMfY1zIDNAZ+xjiRMD1NfTZibvcdh5/mWwF8DryTCvswxN5Mi85kxtJpAmhQGSErtUZTytXWvlcLADWSsIAguuDVzCE2Eu8f3kh/fS/3cEvmw8/UyVZkHXgT+CnOhDidCUklgR8UYGl2iaZToobgkGA0H99vmco1g7D7M3boPfI4Fc7eB1rA/SADeXiBZ3MO8WkruDRG+nQjPZ449MykylwUXyU0HM4fJIMaidPXXEB3rMJw6GAnrwM1v7KG9uIf87NJqTy0yNcOSIEeAvwBOpo5axRk757PCUX9cJBEQB2T2+R4WLIyQp7Hcb13gAgZyiwE+bALw0l52q/BNEd5MHN9KHUdmM9K5FKmlJYM0hewcJGW9GjNhnkIFDPFjEyyybAOoIgq3X9pF/aXd6Lm7hQaJTJ0HviHCSed4MnPIbApz6dZi8mmQGMTUgsleHu7Hxkj8EPB9IFFj7BIhvxO/mP7oBfYBTwkcTYSv1Rx7ailSTSCbxATHIyRdtmLBi5MiZ5CvzhXEMboLi4ZvCZxE8NjMwe34xRRLMh8WeC4VDs6kZNEP/SpJzJ61U0u+NHNrg76KGa8jGGPBPIMuqMnx3fwgFY5UHa9UEw7NZriZpDeL9LhL1LFOgjMgvbMK/V/H9KsDZhBWEL54aQ93XtpDfu4OeQq8nAj7ayk7a4k9sWn1Q8ch8f5zD+0wsdIZbLhmMY9gQeEFzIe9DLTSxECdrybsrKWmtB8HC79ZSZ3pxFoCnRTIIe8MYKxQASqqHMLc0CURln7yKvfS1HEsFSqZY77yFWdpWaIbScsYmw+fQTgAvCbCCnAeuJpmjv2pw6VCmn7FjNMoSRzUBFpBJQ5TAyLswNysF4Anl+5xJZ3NyFKHJLJq0ddXWhygYq7WXAaNjuVjB7iwGTCnNoF4LPc001pKGmc0JyXS/1lW/7wsGv7ZwHz+2CX6sBUHmtoUTdODrvYI4pKlJ4AXUbK0kkwu89RNCtMXGtL7OUo5TIyLJWJ7WOAmzmLTjocsN3CHeAO7sHm8g2l08sdBVCkdyznLpAyoFA8x/j9KXAyRB1Dz4CsKBbDbDW4ikCSQeWNtrpAPSBWKuVjPAwfSfrZsRoQAVGnmNAJaZmb3+9L7AMo/13AjTu2oUoSMHTXGPAzWpmLzcZ4wY7D6IjJstmA+3cqwl1JL+ub5BzFxvX32fjC2+pCy8DGjtM3Ips5yym0fslqDQc1gCwvUusykWM4TE9jjDm+jyshCYNLxlsRcx1Tz2CTOzMYcQRxBg2TzoJaX8PRl1MctcS5JtJhU82EIbheukTQR2FEGdMOgxoVmcYFCwvaFtfE0mbPPbdZczjN2SYLv6jUYrQHn3jCoqRSLJrZ7nr9s4Fyg7LYzNkzN5zo0Nbh+UKMBisboYSZd4qkTZ9niNsGYbcO5o25PIwZbYWqkfSoPf4olMjYlRIJqXsF20DUuyEjdcGO8JqjR30xdYeUfFekGF858GfEjs0njOacUq72HYbEmqPGi4/B/1EQIQYILs2+jF0aM7Xzd9Q+sPt+aoCbBZYqdPEoSryfuNVIBH9J0k9Kv3XOWgpx+12qkdoxPJXOPJkujxOvsLjAeoe/Gfc5Bgc5QUGP4OQ0TgN2JOwrLvB26P+LTD87Q4d+fEJkGESnUwKS3S4/CZzioZWU8JahK+Cfqu5iT3W4ZOPy7rsoUARql7GYlE1ZbOiTBO3L4T8Mq6bJ0kzr0Zs0mkSbUvlaW4YZKpg/UKNEyT5ypDPaJR1r/aZ1ejdfumByo3W2crB4Ja7pU06ZTo0zaFVQtpnk2FFFNK6A9CXOx5Pa41GpMM3aT1EXHXW0wGlSmU6eWZdzXX05O9+lUxTZZ6HYUpnmsxBO2vffNqKqt/78DNEeC+jBXiIxLxn39XkNNAV2VtHmAbWm/NZqppe0w0yRdBgVWjAXY0IlXW77eKZgau18GLip8OhTULkunFFiYzCjLYw2B/gUVyl2sPNOZx1anqo53QjBa/I4PRRmKnG0L27B2DfgYz4ePJahhMUvP3qitSh4Aba/euXIX+AzhPMp14PZjCSoUfuRWpbxoLg774E7FJNhNrPTSHxCu/ezP3F1Tp06j9Y/RTq6MJZmiGENXQtGb8LBaFBb/XeA0tlFttPM/bYB2i4ExPITcqEQ6tnNoGFOjqn4AXEE5B7zfbvIRITc+nKnxoqbM8o97sXDHG5iNvFtYzGOR0zXg1yKcVuVm+JmFqWpfsqS5FM7ToHzho4pvuXJaDCNjBmmrfbY8LHegkaOhkkWL4JMC/+mE3yPc/LdrRVGFVG2rddikbcztXpy3SbRpkTwM03EsWovWvtmxTRRt363MdJGiytqfMD3aU1AhBRoacrrlX3gNCwWmRLFGIrR1POuqYkW2Zm6gapEw+RT4pQgfAJdPXeB+/9+mwK+wTQAvYnX8ei4yrrt/FBdTxAfeCdfYXrsM3ZoSawQut63EXSO37jGG/hGz9B8C1wnV7/olBX6N7bGMxWS7Ulb6cabyURMlhI5+fAxthhpW91vgDdAmtpvv5wJ/AC799AKNYX2kKL9BOKKwiHIYqIjtu+yepO0BZ5sb4OEzNrIx98Xmiq0wVLWIlFY63SKM99UM0lnMuT8TPt9kjWUFqeS8rwlN4IYKK8FodUGNqS4nfTU8H6J043C1OHyrK/2UYJRyWGnDgzYoLCt8CZwW+DnmQt3AWDtyQKRJh3on4QbC/2H7sF5W+DphMtWHs3ZCN3GXcZTtYG1PhV8trHs8bhTQcn9tq0ShjU63guXnqtxQOKPCeYH3gcsi3AOa6yljnwJ5knAb+JUqLbV6KsfC7wXC3qFgDMA2a3V/uU2iFKpoHPupYn/13JgZS4ICV7GQ85cK/+PhTgIN2UB+Jvmvm/C9Z0EEr4oAM6jV1RcDGEpBQVycMKz3rTK3x5En+IsBxE45pt9k35HhjRzqHXwjp9HMuZt7PvbKe1jd1N8C53LhSsvRaAv+Fxfg7NL6zhNHchu4LfAngaqa3vh77LUb3ZvU4Lt1MDWQuWJV8ThZ2+POaeHmxIe5aYNEUR9l2XZF57nnQe65rvDfwP9SvFyhDjQ2c7oeLN45yQz2poijCn8D/KXCAsJzFKsVgd4a0+U59vLSm+5xCOj9hbnjg+upjq7FcaNSnk4OuVDf8uStnHoj50bTc02VK165gPKemHW/9dNL3Nr42QrpT6g0MCu3LMbePyv8EPNfYzEWoLjZ8kbehN5l2+Wd0vEPhRKIpZvuT4SUDdBWmBmNUXCVfMvTbOXcVnhPld8CZ7Ho6AHKMmNYhTlw1L5zkgrwlMIzHt5S+I5YgPAkVvJyrtRBNy7o2YZe+uWgxW79ulNLQG7W5yw/pKA6fMfTaXvqzZylZs6ttudmy/Mp8EFg5mU3w2XAn/pwPNnOYam/NuaT3VOruXTGw3eB1wWekxKo3RuilBmKQUL8ZZ9K6H5F+/7P5llZvoZSuq7TzFlpe26qciZXzih8hL1HZQmbCqkz3pmX0fbln19DsJfK7MKKs54IoB4CdqPd96HE+v5pOX04MYl+Jl1VoYGdzVxZzpXlZs7dVs7tRs4Xbc914GNvYF7KMz4DOv9+fngN1K3IWnNUinkCS5jvdhGri79flWMKx1FeABZEmJXJvlxmlXRnN80Iaduz3PZc88pVr1zwygXggsANtdUj97CMfawvPRHZMADvvME8MN/ucFSVRex9KQsO5kWYw8rX14CaFu+WirnalEL1Dl3pWNYKQU9aLlPJCTkPVVq50mgrjXZOveWpt3JuNj2fdTxXsOKGl5zj8p5d3AH8v5zenhmizcymNjALeQ6LPuaxajez4fMB4IBXngqvmNtHePuZwKwIVbG3pqVS8ij63SpVAzJXvLfy8B2v1L2ykitf5p7bOXzulesK10No+SU2qh5gyZDYxqoz15KxDdV/epUZYB7lOeA5ryx4ZQF7c8UTCHslAOuEmgjVGDuUHfouoIr6AGrH086Vdq488Mq9Vs61Vs7nHeVyrlxSuCjCpyLcApZPfTIZXble+X8T1+1wg9CWEQAAAABJRU5ErkJggg==
"
x="0"
y="35"
width="85"
height="85" />
<rect
width="85"
height="35"
ry="7.75"
x="0"
y="0"
style="fill:#ffffff;fill-opacity:1;stroke:none" />
</svg>
```
This will give the shape of a rock, (my custom image). The base64 strings are compiled on the spot.

@quozl @tchx84 Please review