### PR TITLE
Fix fail to start, XML parse error

### DIFF
--- a/svg_utils.py
+++ b/svg_utils.py
@@ -130,6 +130,9 @@ def svg_header(w, h, scale):
     v += '<!-- Created with Python -->\n'
     v += '<svg\n'
     v += '   xmlns:svg="http://www.w3.org/2000/svg"\n'
+    v += '   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"\n'
+    v += '   xmlns:cc="http://creativecommons.org/ns#"\n'
+    v += '   xmlns:dc="http://purl.org/dc/elements/1.1/"\n'
     v += '   xmlns="http://www.w3.org/2000/svg"\n'
     v += '   version="1.0"\n'
     v += '   width="%f"\n' % (w * scale)


### PR DESCRIPTION
On Ubuntu 20.04 with librsvg 2.48.0 the activity does fail to start and logs contain;

```log
Traceback (most recent call last):
  File "/usr/share/sugar/activities/FractionBounce.activity/FractionBounceActivity.py", line 91, in __init__
    self._bounce_window = Bounce(canvas, activity.get_bundle_path(), self)
  File "/usr/share/sugar/activities/FractionBounce.activity/bounce.py", line 144, in __init__
    self._create_sprites(path)
  File "/usr/share/sugar/activities/FractionBounce.activity/bounce.py", line 236, in _create_sprites
    self.ball = Ball(self._sprites,
  File "/usr/share/sugar/activities/FractionBounce.activity/ball.py", line 109, in __init__
    self._sprites, 0, 0, svg_str_to_pixbuf(
  File "/usr/share/sugar/activities/FractionBounce.activity/svg_utils.py", line 58, in svg_str_to_pixbuf
    pl.close()
gi.repository.GLib.Error: rsvg-error-quark: XML parse error: error code=201 (3) in (null):14:13: Namespace prefix rdf on RDF is not defined (0)
```

librsvg 2.47.0 introduced [stricter namespaces in the XML parser](https://gitlab.gnome.org/GNOME/librsvg/-/blob/master/NEWS#L67), so add namespace declarations.

@srevinsaju, for your review.